### PR TITLE
Fixes persistence issue.

### DIFF
--- a/charactersheet/charactersheet/models/character/death_save.js
+++ b/charactersheet/charactersheet/models/character/death_save.js
@@ -2,8 +2,7 @@ function DeathSave() {
     var self = this;
     self.ps = PersistenceService.register(DeathSave, self);
     self.mapping = {
-        ignore: ['clear', 'ps', 'importValues', 'exportValues', 'save', 'delete',
-                'mapping']
+        include: [ 'characterId', 'deathSaveSuccess', 'deathSaveFailure' ]
     };
 
     self.characterId = ko.observable(null);
@@ -45,16 +44,19 @@ function DeathSave() {
     });
 
     self.clear = function() {
+        var mapping = ko.mapping.autoignore(self, self.mapping);
         var values = new DeathSave().exportValues();
-        ko.mapping.fromJS(values, self.mapping, self);
+        ko.mapping.fromJS(values, mapping, self);
     };
 
     self.importValues = function(values) {
-        ko.mapping.fromJS(values, self.mapping, self);
+        var mapping = ko.mapping.autoignore(self, self.mapping);
+        ko.mapping.fromJS(values, mapping, self);
     };
 
     self.exportValues = function() {
-        return ko.mapping.toJS(self, self.mapping);
+        var mapping = ko.mapping.autoignore(self, self.mapping);
+        return ko.mapping.toJS(self, mapping);
     };
 
     self.save = function() {

--- a/charactersheet/charactersheet/templates/character/stats.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/stats.tmpl.html
@@ -68,16 +68,14 @@
         <div class="input-group">
           <span class="input-group-addon">Death Save Successes</span>
            <div class="form-control hit-dice-list" data-bind="foreach: deathSaveSuccessList">
-            <span class="ds-success-full"
-                  data-bind="attr: { id: $index, name: $index }, click: deathSaveSuccessHandler,
+            <span data-bind="attr: { id: $index, name: $index }, click: deathSaveSuccessHandler,
                   css: deathSaveSuccessIcon"></span>
           </div>
 
           <span class="input-group-addon">Death Save Failures</span>
           <div class="form-control hit-dice-list"
                data-bind="foreach: deathSaveFailureList">
-            <span class="ds-failure-full"
-                  data-bind="attr: { id: $index, name: $index }, click: deathSaveFailureHandler,
+            <span data-bind="attr: { id: $index, name: $index }, click: deathSaveFailureHandler,
                   css: deathSaveFailureIcon"></span>
 
           </div>


### PR DESCRIPTION
### Summary of Changes

The issue was 2-fold:
- The css class was hard-coded as the success class (which didn't seem to be causing the issue, but must have been doing something wrong).
- Once persisted, the icon css fields were being read from the database. Upgrading to new auto-ignore paradigm fixed the issue.